### PR TITLE
Add "show all" in auto-completion

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -279,8 +279,11 @@ class CustomersController < ApplicationController
     @customers_s =
       Customer.find_by_multiple_terms(s.split( /\s+/)).
           reject {|customer| @customers.include?(customer)}
-    result = @customers.map do |c|
-      {'label' => c.full_name, 'value' => customer_path(c)}
+    session[:customers_filter] = params[:term]
+    result = Array[{'label' => 'show all',
+                    'value' => customers_path(:customers_filter => session[:customers_filter])}]
+    @customers.map do |c|
+      result.push({'label' => c.full_name, 'value' => customer_path(c)})
     end
     customer_hash = Customer.find_by_terms_col(s)
     @customers_s.each do |c|

--- a/features/customers/search_with_autocomplete.feature
+++ b/features/customers/search_with_autocomplete.feature
@@ -13,7 +13,8 @@ Background: I am logged in as boxoffice
 Scenario: search with multiple match
 
   When I fill "search_field" autocomplete field with "Bagg"
-  Then I should see autocomplete choice "Bilbo Baggins" 
+  Then I should see autocomplete choice "show all"
+  And I should see autocomplete choice "Bilbo Baggins" 
   And I should see autocomplete choice "Frodo Baggins"
   But I should not see autocomplete choice "Bob Bag"
   When I select autocomplete choice "Bilbo Baggins"
@@ -22,7 +23,7 @@ Scenario: search with multiple match
 Scenario: search with no matches
 
   When I fill "search_field" autocomplete field with "xyz"
-  Then I should not see any autocomplete choices
+  Then I should see autocomplete choice "show all"
 
 Scenario:search with other information
   Given the following Customers exist:
@@ -34,7 +35,8 @@ Scenario:search with other information
     | Organ      | Milk      | dancingfox@mail.com | 100 bway      |  SAF | CA    |
 
   When I fill "search_field" autocomplete field with "Fox"
-  Then I should see autocomplete choice "Armando Fox"
+  Then I should see autocomplete choice "show all"
+  And I should see autocomplete choice "Armando Fox"
   And I should see autocomplete choice "Bobby Boxer(123 Fox Hill)"
   And I should see autocomplete choice "Organ Milk(dancingfox@mail.com)"
   But I should not see autocomplete choice "Bob Bag"


### PR DESCRIPTION
When using auto-completion, the first row of the result list is "show all" whose value is a path to show all customers who contain the keyword in their information. The only methods modified is auto_complete_for_customer in customer controller.